### PR TITLE
5 mauvaise tiles autour du pont sur la map light worldwooden bridge

### DIFF
--- a/correction.txt
+++ b/correction.txt
@@ -1,0 +1,1 @@
+closed issue test 2

--- a/correction.txt
+++ b/correction.txt
@@ -1,1 +1,1 @@
-close #issue test 3
+test 4 Closes #8 test 

--- a/correction.txt
+++ b/correction.txt
@@ -1,1 +1,1 @@
-closed issue test 2
+close #issue test 3


### PR DESCRIPTION
Erreur de mapping d'origine dans "The Legend of Zelda : A Link to the Past"

close #8 