### PR TITLE
Correction de Tile de Map Stone Bridge

### DIFF
--- a/correction.txt
+++ b/correction.txt
@@ -1,1 +1,1 @@
-test 4 Closes #8 test 
+okay test 5 de closing d'issue ! #8 !


### PR DESCRIPTION
Correction de Tile de Map Stone Bridge: L'erreur de Mapping est d'origine à **The Legend of Zelda : A Link to the Past**

close #8